### PR TITLE
Repoint travelnet to the new mt-mods fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -261,7 +261,7 @@
 	url = https://github.com/BlockySurvival/titanium.git
 [submodule "travelnet"]
 	path = travelnet
-	url = https://github.com/BlockySurvival/travelnet.git
+	url = https://github.com/mt-mods/travelnet.git
 [submodule "tubelib2"]
 	path = tubelib2
 	url = https://github.com/BlockySurvival/tubelib2.git


### PR DESCRIPTION
This adds coloured travelnets as well as fixing several bugs, and makes updating travelnets redundant.

This fork is also actively maintained and should be considered the new canonical source.

Fixes https://github.com/BlockySurvival/issue-tracker/issues/326

Makes https://github.com/BlockySurvival/issue-tracker/issues/288 redundant